### PR TITLE
feat: upgrade guzzle to 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   ],
   "require": {
     "php": ">=7.1.0",
-    "guzzlehttp/guzzle": "^6.3.3",
-    "ext-json": "*"
+    "ext-json": "*",
+    "guzzlehttp/guzzle": "^7.1.1"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",


### PR DESCRIPTION
Guzzle 6 is no longer receiving bug fixes and many libraries are forcing the version to ^7.0 causing incompatibility (ex: Laravel 9)