### PR TITLE
Fix composer.json with required allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-vcr/php-vcr": "^1.5.2",
-    "php-vcr/phpunit-testlistener-vcr": "^3.3.1",
+    "covergenius/phpunit-testlistener-vcr": "^3.3.1",
     "phpunit/phpunit": "^9.0",
     "symfony/var-dumper": "^4.2",
     "vlucas/phpdotenv": "^2.5"

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,10 @@
   },
   "config": {
     "sort-packages": true,
-    "optimize-autoloader": true
+    "optimize-autoloader": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "php-vcr/php-vcr": "^1.5.2",
+    "covergenius/php-vcr": "^1.7",
     "covergenius/phpunit-testlistener-vcr": "^3.3.1",
     "phpunit/phpunit": "^9.0",
     "symfony/var-dumper": "^4.2",
@@ -59,7 +59,8 @@
     "sort-packages": true,
     "optimize-autoloader": true,
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "php-http/discovery": true
     }
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "covergenius/php-vcr": "^1.7",
+    "php-vcr/php-vcr": "^1.5.2",
     "covergenius/phpunit-testlistener-vcr": "^3.3.1",
     "phpunit/phpunit": "^9.0",
     "symfony/var-dumper": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-vcr/php-vcr": "^1.5.2",
-    "php-vcr/phpunit-testlistener-vcr": "dev-master as 3.3.1",
+    "php-vcr/phpunit-testlistener-vcr": "^3.3.1",
     "phpunit/phpunit": "^9.0",
     "symfony/var-dumper": "^4.2",
     "vlucas/phpdotenv": "^2.5"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-vcr/php-vcr": "^1.5.2",
-    "php-vcr/phpunit-testlistener-vcr": "dev-master as 3.2.1",
+    "php-vcr/phpunit-testlistener-vcr": "dev-master as 3.3.1",
     "phpunit/phpunit": "^9.0",
     "symfony/var-dumper": "^4.2",
     "vlucas/phpdotenv": "^2.5"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,6 @@
     </testsuite>
   </testsuites>
   <listeners>
-    <listener class="VCR\PHPUnit\TestListener\VCRTestListener" file="vendor/php-vcr/phpunit-testlistener-vcr/src/VCRTestListener.php"/>
+    <listener class="VCR\PHPUnit\TestListener\VCRTestListener" file="vendor/covergenius/phpunit-testlistener-vcr/src/VCRTestListener.php"/>
   </listeners>
 </phpunit>


### PR DESCRIPTION
After recent changes CI broke due to composer requiring allow-plugins object to be added for one of our dependencies, this PR adds this object with the required entry.