### PR TITLE
Remove deprecated function usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
   "require": {
     "php": "^7.4.0||^8.0",
     "guzzlehttp/guzzle": "^7.2",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-vcr/php-vcr": "^1.5.2",
     "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan-deprecation-rules": "^1.1",
     "phpunit/phpunit": "^9.0",
-    "symfony/var-dumper": "^4.2",
     "vlucas/phpdotenv": "^2.5"
   },
   "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - phpstan-baseline.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
     paths:

--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -109,7 +109,7 @@ class AuthMiddleware
             hash_hmac(
                 static::SIGNATURE_ALGORITHM,
                 $signatureContentString,
-                utf8_encode($this->apiSecret),
+                mb_convert_encoding($this->apiSecret, 'UTF-8', mb_detect_encoding($this->apiSecret)),
                 true
             )
         );

--- a/src/XCover.php
+++ b/src/XCover.php
@@ -5,8 +5,8 @@ namespace XCoverClient;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Utils;
 use GuzzleHttp\HandlerStack;
-use Psr\Http\Message\ResponseInterface;
 use XCoverClient\Exceptions\ResponseException;
 use XCoverClient\Exceptions\XCoverException;
 use XCoverClient\Middleware\AuthMiddleware;
@@ -50,7 +50,7 @@ class XCover
     public function call($method, $url, $expectedStatusCode = null, $payload = [], $queryParams = [])
     {
         $options = [
-            'body' => $payload ? \GuzzleHttp\json_encode($payload) : "{}",
+            'body' => $payload ? Utils::jsonEncode($payload) : "{}",
             'query' => $queryParams,
         ];
 


### PR DESCRIPTION
utf8_encode is deprecated from PHP 8.2 onwards, so we'll remove it to get rid of warnings and be better prepared for future PHP releases.

It's replaced with mbstring, which I've added to composer as a requirement to make sure consumers will not pick up this version of the package if they will not be able to run the newly changed line.